### PR TITLE
feat: add p13n support

### DIFF
--- a/src/components/EditableArea.tsx
+++ b/src/components/EditableArea.tsx
@@ -1,4 +1,5 @@
 import { useEditor } from '../hooks';
+import { getContentVariant } from '../util';
 import { Comment } from './Comment';
 import { EditableComponent, EditableComponentProps } from './EditableComponent';
 
@@ -17,7 +18,7 @@ export const EditableArea = <
   T extends {} = React.HTMLAttributes<HTMLDivElement>
 >({
   children,
-  content,
+  content: originalContent,
   renderArea: propsRenderArea,
   renderComponent: propsRenderComponent,
   ...props
@@ -36,6 +37,7 @@ export const EditableArea = <
     editorRenderComponent ??
     (props => <EditableComponent {...props} />);
 
+  const content = getContentVariant(originalContent, templateAnnotations);
   const component = renderArea({
     ...props,
     children: [
@@ -53,7 +55,7 @@ export const EditableArea = <
   if (isEditor) {
     return (
       <Comment
-        openComment={templateAnnotations?.[content['@path']]}
+        openComment={templateAnnotations?.[originalContent?.['@path']]}
         closeComment="/cms:area"
       >
         {component}

--- a/src/components/EditableComponent.tsx
+++ b/src/components/EditableComponent.tsx
@@ -1,20 +1,23 @@
 import { useEditor } from '../hooks';
-import { getRenderedComponent } from '../util';
+import { getContentVariant, getRenderedComponent } from '../util';
 import { Comment } from './Comment';
 
 export type EditableComponentProps = {
   content: any;
 };
 
-export const EditableComponent = ({ content }: EditableComponentProps) => {
+export const EditableComponent = ({
+  content: originalContent
+}: EditableComponentProps) => {
   const { componentMappings, isEditor, templateAnnotations } = useEditor();
 
+  const content = getContentVariant(originalContent, templateAnnotations);
   const component = getRenderedComponent(content, componentMappings);
 
   if (isEditor) {
     return (
       <Comment
-        openComment={templateAnnotations?.[content?.['@path']]}
+        openComment={templateAnnotations?.[originalContent?.['@path']]}
         closeComment="/cms:component"
       >
         {component}

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -13,7 +13,7 @@ export const EditorContext = createContext<{
   renderComponent?: <T extends EditableComponentProps>(
     props: T
   ) => React.ReactElement;
-  templateAnnotations?: { [template: string]: string };
+  templateAnnotations?: Record<string, string>;
 }>({});
 
 export const useEditor = () => useContext(EditorContext);

--- a/src/util/component.ts
+++ b/src/util/component.ts
@@ -1,7 +1,11 @@
-import { createElement as _createElement } from 'react';
+import { createElement } from 'react';
 
-export const getComponentProperties = content => {
-  const props = { key: content['@id'], metadata: {} };
+export const getComponentProperties = (content: any) => {
+  const props: {
+    key: string;
+    metadata: Record<string, string>;
+    [name: string]: unknown;
+  } = { key: content['@id'], metadata: {} };
 
   Object.keys(content).forEach(key => {
     if (
@@ -19,9 +23,8 @@ export const getComponentProperties = content => {
 };
 
 export const getRenderedComponent = (
-  content,
-  componentMappings,
-  createElement = _createElement
+  content: any,
+  componentMappings?: Record<string, React.ComponentType<any>>
 ) => {
   if (!content || !componentMappings) {
     return createElement('div');

--- a/src/util/editor.ts
+++ b/src/util/editor.ts
@@ -1,0 +1,13 @@
+export const isInIFrame = () =>
+  typeof window === 'undefined' ? false : window !== window.parent;
+
+export const isInEditor = () =>
+  isInIFrame() && window.parent.location.hash.endsWith(':edit');
+
+export const isInPreviewAsVisitor = () =>
+  isInIFrame() && window.location.search.includes('mgnlPreviewAsVisitor=true');
+
+export const refreshEditor = () => {
+  window.parent.mgnlFrameReady?.();
+  window.parent.mgnlRefresh?.();
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,3 @@
+export * from './component';
+export * from './editor';
+export * from './p13n';

--- a/src/util/p13n.ts
+++ b/src/util/p13n.ts
@@ -1,0 +1,32 @@
+import { isInEditor, isInPreviewAsVisitor } from './editor';
+
+export const getContentVariant = (
+  content: any,
+  templateAnnotations?: Record<string, string>
+) => {
+  if (
+    !content ||
+    !templateAnnotations ||
+    !isInEditor() ||
+    isInPreviewAsVisitor()
+  ) {
+    return content;
+  }
+
+  const variant = templateAnnotations[content['@path']]?.match(
+    /selectedVariant="(.+)"/
+  )?.[1];
+
+  if (!variant || variant === content['@name']) {
+    return content;
+  }
+
+  const contentVariant = content[variant];
+
+  if (!contentVariant) {
+    console.warn(`Missing variant ${variant} for content ${content['@path']}.`);
+    return content;
+  }
+
+  return contentVariant;
+};


### PR DESCRIPTION
introduces personalisation support for all editable content in the magnolia spa editor. only works when using template annotations and not template definitions.